### PR TITLE
Add ModMenu client badge and recommendation

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,9 @@
       "net.heyzeer0.sd.integrations.SDModMenuIntegration"
     ]
   },
+  "custom": {
+    "modmenu:clientsideOnly": true
+  },
   "mixins": [
     "shieldisruptor.mixins.json"
   ],
@@ -34,5 +37,8 @@
     "minecraft": "1.16.x",
     "autoconfig1u": "*",
     "cloth-config2": "*"
+  },
+  "recommends": {
+    "modmenu": "*"
   }
 }


### PR DESCRIPTION
The mod [**ModMenu**](https://www.curseforge.com/minecraft/mc-mods/modmenu) has the option to display a **"Client"** badge besides the mod name. However, it needs to be specified in the `fabric.mod.json`.
ModMenu is widely used and recommended by popular mods, thus ShieldDisruptor should add support too.

### This pull request:
- Adds the client badge
![2020-07-11_12 36 11](https://user-images.githubusercontent.com/42546705/87222332-248b8480-c373-11ea-831c-30c64d079706.png)
- Adds a recommendation for ModMenu
![recommends](https://user-images.githubusercontent.com/42546705/87222473-1db14180-c374-11ea-8ed2-c6a8a1b97df1.png)

I think this is a small but useful change, however feel free to close this pr nonetheless.